### PR TITLE
chore: add Larastan static analysis (level 5)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: "8.4"
 
       - name: Add Flux Credentials Loaded From ENV
         run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
@@ -44,3 +44,23 @@ jobs:
       #     file_pattern: |
       #       **/*
       #       !.github/workflows/*
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    environment: Testing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+
+      - name: Add Flux Credentials Loaded From ENV
+        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
+
+      - name: Install Dependencies
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Run Larastan
+        run: vendor/bin/phpstan analyse --no-progress --memory-limit=1G

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpunit.cache
+/build
 /node_modules
 /public/build
 /public/hot

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "fakerphp/faker": "^1.23",
         "fruitcake/laravel-debugbar": "^4.0",
         "joshcirre/tweakflux": "^1.6",
+        "larastan/larastan": "^3.0",
         "laravel/boost": "^2.0",
         "laravel/pail": "^1.2.2",
         "laravel/pint": "^1.24",
@@ -72,6 +73,10 @@
             "vendor/bin/pint",
             "@php artisan config:clear --ansi",
             "@php artisan test"
+        ],
+        "analyse": [
+            "@php artisan config:clear --ansi",
+            "vendor/bin/phpstan analyse --memory-limit=1G"
         ],
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e982f7ea603d7f214efb0a2280982d1b",
+    "content-hash": "05a10373b5151e52aa4f46405e288b0c",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9401,6 +9401,47 @@
             "time": "2025-04-30T06:54:44+00:00"
         },
         {
+            "name": "iamcal/sql-parser",
+            "version": "v0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/iamcal/SQLParser.git",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/iamcal/SQLParser/zipball/610392f38de49a44dab08dc1659960a29874c4b8",
+                "reference": "610392f38de49a44dab08dc1659960a29874c4b8",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^1.0",
+                "phpunit/phpunit": "^5|^6|^7|^8|^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "iamcal\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Cal Henderson",
+                    "email": "cal@iamcal.com"
+                }
+            ],
+            "description": "MySQL schema parser",
+            "support": {
+                "issues": "https://github.com/iamcal/SQLParser/issues",
+                "source": "https://github.com/iamcal/SQLParser/tree/v0.7"
+            },
+            "time": "2026-01-28T22:20:33+00:00"
+        },
+        {
             "name": "jean85/pretty-package-versions",
             "version": "2.1.1",
             "source": {
@@ -9513,6 +9554,96 @@
                 "source": "https://github.com/joshcirre/tweakflux/tree/v1.6.0"
             },
             "time": "2026-02-13T23:00:16+00:00"
+        },
+        {
+            "name": "larastan/larastan",
+            "version": "v3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/larastan/larastan.git",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/larastan/larastan/zipball/2970f83398154178a739609c244577267c7ee8eb",
+                "reference": "2970f83398154178a739609c244577267c7ee8eb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "iamcal/sql-parser": "^0.7.0",
+                "illuminate/console": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/container": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/contracts": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/database": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/http": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/pipeline": "^11.44.2 || ^12.4.1 || ^13",
+                "illuminate/support": "^11.44.2 || ^12.4.1 || ^13",
+                "php": "^8.2",
+                "phpstan/phpstan": "^2.2.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "laravel/framework": "^11.44.2 || ^12.7.2 || ^13",
+                "mockery/mockery": "^1.6.12",
+                "nikic/php-parser": "^5.4",
+                "orchestra/canvas": "^v9.2.2 || ^10.0.1 || ^11",
+                "orchestra/testbench-core": "^9.12.0 || ^10.1 || ^11",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpunit/phpunit": "^10.5.35 || ^11.5.15 || ^12.5.8 || ^13.1.8"
+            },
+            "suggest": {
+                "orchestra/testbench": "Using Larastan for analysing a package needs Testbench",
+                "phpmyadmin/sql-parser": "Install to enable Larastan's optional phpMyAdmin-based SQL parser automatically"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Larastan\\Larastan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Can Vural",
+                    "email": "can9119@gmail.com"
+                }
+            ],
+            "description": "Larastan - Discover bugs in your code without running it. A phpstan/phpstan extension for Laravel",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "larastan",
+                "laravel",
+                "package",
+                "php",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/larastan/larastan/issues",
+                "source": "https://github.com/larastan/larastan/tree/v3.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/canvural",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-28T08:00:58+00:00"
         },
         {
             "name": "laravel/boost",
@@ -10930,6 +11061,70 @@
                 "source": "https://github.com/php-debugbar/symfony-bridge/tree/v1.1.0"
             },
             "time": "2026-01-15T14:47:34+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.8",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e285254e60f33c21902efef4a926ca0987c06804",
+                "reference": "e285254e60f33c21902efef4a926ca0987c06804",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-04T22:21:45+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,9 @@ and keep new features consistent with the rules below.
    committing.
 2. **Everything is fully typed** — parameters, return types, properties, and array-shape
    PHPDocs (`@return array{...}`, `@param array<string, mixed>`). Eloquent relations use
-   generics (`BelongsTo<Role, $this>`, `HasMany<MenuSub, $this>`).
+   generics (`BelongsTo<Role, $this>`, `HasMany<MenuSub, $this>`). Types are enforced by
+   **Larastan (PHPStan level 5)** — run `composer analyse` before committing; new code must
+   not add errors to `phpstan-baseline.neon`.
 3. **Business logic lives in Action classes, never in components or controllers.**
 4. **Data crossing a boundary is wrapped in a DTO** — never pass raw request arrays into
    Actions.
@@ -134,6 +136,9 @@ Reusable, fully-typed cross-cutting helpers: `WithSaveFile`, `WithMediaCollectio
   `*.test.php` files next to each Livewire component.
 - Feature tests use `RefreshDatabase` and model factories.
 - Run the suite: `php artisan test --compact` or `composer test`.
+- **Static analysis:** run `composer analyse` (Larastan, PHPStan level 5). Config lives in
+  `phpstan.neon.dist`; existing errors are captured in `phpstan-baseline.neon` and should
+  shrink over time, never grow.
 - Use the **TIA engine** while iterating: `vendor/bin/pest --tia` re-runs only the tests
   affected by your changes; `vendor/bin/pest --tia --fresh` re-records the baseline graph.
 - A new Action, DTO transformation, or component branch **must** have a test covering it.
@@ -149,4 +154,4 @@ Reusable, fully-typed cross-cutting helpers: `WithSaveFile`, `WithMediaCollectio
 6. Permissions are auto-generated per model by the `PermissionSeeder` — see
    [RBAC](features/rbac.md).
 7. Write tests (component `*.test.php` + any feature/unit tests).
-8. `vendor/bin/pint` → `php artisan test --compact` → update [CHANGELOG](../CHANGELOG.md).
+8. `vendor/bin/pint` → `composer analyse` → `php artisan test --compact` → update [CHANGELOG](../CHANGELOG.md).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,427 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#1 \$credentials of static method Illuminate\\Support\\Facades\\Password\:\:sendResetLink\(\) expects array, string given\.$#'
+			identifier: argument.type
+			count: 1
+			path: app/Actions/Api/V1/Auth/ResetPasswordAction.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:addMedia\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: app/Actions/Api/V1/Auth/UpdateAuthenticatedAction.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Database\\Eloquent\\Model\:\:clearMediaCollection\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: app/Actions/Api/V1/Auth/UpdateAuthenticatedAction.php
+
+		-
+			message: '#^Method App\\Actions\\Cms\\Management\\Permission\\StorePermissionAction\:\:handle\(\) should return App\\Models\\Spatie\\Permission but returns Spatie\\Permission\\Contracts\\Permission\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Actions/Cms/Management/Permission/StorePermissionAction.php
+
+		-
+			message: '#^Method App\\Actions\\Cms\\Management\\Role\\StoreRoleAction\:\:handle\(\) should return App\\Models\\Spatie\\Role but returns Spatie\\Permission\\Contracts\\Role\.$#'
+			identifier: return.type
+			count: 1
+			path: app/Actions/Cms/Management/Role/StoreRoleAction.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\User\:\:\$image\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Http/Controllers/Api/V1/Auth/AuthenticatedController.php
+
+		-
+			message: '#^Using nullsafe property access on non\-nullable type Illuminate\\Http\\Request\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: app/Http/Controllers/Api/V1/Auth/AuthenticatedController.php
+
+		-
+			message: '#^Access to an undefined property App\\Models\\User\:\:\$timezone\.$#'
+			identifier: property.notFound
+			count: 1
+			path: app/Providers/AppServiceProvider.php
+
+		-
+			message: '#^Using nullsafe property access "\?\-\>timezone" on left side of \?\? is unnecessary\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
+			count: 1
+			path: app/Providers/AppServiceProvider.php
+
+		-
+			message: '#^Trait App\\Traits\\WithGenerateReference is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: app/Traits/WithGenerateReference.php
+
+		-
+			message: '#^Trait App\\Traits\\WithGetFilterDataApi is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: app/Traits/WithGetFilterDataApi.php
+
+		-
+			message: '#^Trait App\\Traits\\WithSaveFile is used zero times and is not analysed\.$#'
+			identifier: trait.unused
+			count: 1
+			path: app/Traits/WithSaveFile.php
+
+		-
+			message: '#^Class Spatie\\MediaLibraryPro\\Models\\TemporaryUpload not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: config/media-library.php
+
+		-
+			message: '#^Match expression does not handle remaining value\: string$#'
+			identifier: match.unhandled
+			count: 3
+			path: database/migrations/2026_01_25_113506_create_pulse_tables.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/menu/sub/⚡create-update/create-update.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/menu/sub/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/menu/sub/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method App\\Livewire\\BaseComponent@anonymous/resources/views/components/cms/management/menu/sub/⚡table/table\.php\:15\:\:view\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/cms/management/menu/sub/⚡table/table.php
+
+		-
+			message: '#^Expression "new class extends \\App\\Livewire\\BaseComponent…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/menu/sub/⚡table/table.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/menu/sub/⚡table/table.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/menu/sub/⚡table/table.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/menu/⚡create-update/create-update.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/menu/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/menu/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method App\\Livewire\\BaseComponent@anonymous/resources/views/components/cms/management/menu/⚡table/table\.php\:14\:\:view\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/cms/management/menu/⚡table/table.php
+
+		-
+			message: '#^Expression "new class extends \\App\\Livewire\\BaseComponent…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/menu/⚡table/table.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/menu/⚡table/table.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/menu/⚡table/table.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/permission/⚡create-update/create-update.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/permission/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/permission/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method App\\Livewire\\BaseComponent@anonymous/resources/views/components/cms/management/permission/⚡table/table\.php\:13\:\:view\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/cms/management/permission/⚡table/table.php
+
+		-
+			message: '#^Expression "new class extends \\App\\Livewire\\BaseComponent…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/permission/⚡table/table.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/permission/⚡table/table.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/permission/⚡table/table.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/role/⚡create-update/create-update.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/role/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/role/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Expression "new class extends \\App\\Livewire\\BaseComponent…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/role/⚡permission/permission.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: resources/views/components/cms/management/role/⚡permission/permission.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: resources/views/components/cms/management/role/⚡permission/permission.test.php
+
+		-
+			message: '#^Call to an undefined method App\\Livewire\\BaseComponent@anonymous/resources/views/components/cms/management/role/⚡table/table\.php\:13\:\:view\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/cms/management/role/⚡table/table.php
+
+		-
+			message: '#^Expression "new class extends \\App\\Livewire\\BaseComponent…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/role/⚡table/table.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/role/⚡table/table.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/role/⚡table/table.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/user/⚡create-update/create-update.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/user/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 4
+			path: resources/views/components/cms/management/user/⚡create-update/create-update.test.php
+
+		-
+			message: '#^Call to an undefined method App\\Livewire\\BaseComponent@anonymous/resources/views/components/cms/management/user/⚡table/table\.php\:14\:\:view\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/cms/management/user/⚡table/table.php
+
+		-
+			message: '#^Expression "new class extends \\App\\Livewire\\BaseComponent…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/user/⚡table/table.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/user/⚡table/table.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/user/⚡table/table.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/cms/management/user/⚡update-password/update-password.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/user/⚡update-password/update-password.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:seed\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/cms/management/user/⚡update-password/update-password.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/setting/two-factor/⚡recovery-codes/recovery-codes.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Testing\\TestResponse\:\:assertSet\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/setting/two-factor/⚡recovery-codes/recovery-codes.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: resources/views/components/setting/two-factor/⚡recovery-codes/recovery-codes.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/setting/⚡appearance/appearance.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/setting/⚡appearance/appearance.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/setting/⚡delete-user-form/delete-user-form.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/setting/⚡delete-user-form/delete-user-form.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/setting/⚡password/password.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/setting/⚡password/password.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/setting/⚡profile/profile.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 3
+			path: resources/views/components/setting/⚡profile/profile.test.php
+
+		-
+			message: '#^Expression "new class extends \\Livewire\\Component…" on a separate line does not do anything\.$#'
+			identifier: expr.resultUnused
+			count: 1
+			path: resources/views/components/setting/⚡two-factor/two-factor.php
+
+		-
+			message: '#^Call to an undefined method Illuminate\\Testing\\TestResponse\:\:assertSet\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/setting/⚡two-factor/two-factor.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:actingAs\(\)\.$#'
+			identifier: method.notFound
+			count: 2
+			path: resources/views/components/setting/⚡two-factor/two-factor.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:assertDatabaseHas\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/setting/⚡two-factor/two-factor.test.php
+
+		-
+			message: '#^Call to an undefined method Pest\\PendingCalls\\TestCall\:\:markTestSkipped\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: resources/views/components/setting/⚡two-factor/two-factor.test.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,15 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+    - phpstan-baseline.neon
+
+parameters:
+    level: 5
+    paths:
+        - app
+        - database
+        - routes
+        - config
+        - resources/views/components
+    excludePaths:
+        - resources/views/components/**/*.blade.php
+    tmpDir: build/phpstan

--- a/resources/views/components/cms/management/menu/sub/⚡create-update/create-update.php
+++ b/resources/views/components/cms/management/menu/sub/⚡create-update/create-update.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Symfony\Component\Finder\SplFileInfo;
@@ -22,6 +23,7 @@ use Symfony\Component\Finder\SplFileInfo;
 new class extends Component
 {
     /** @var class-string<MenuSub> */
+    #[Locked]
     public string $modelInstance = MenuSub::class;
 
     public Menu $menu;

--- a/resources/views/components/cms/management/menu/sub/⚡table/table.php
+++ b/resources/views/components/cms/management/menu/sub/⚡table/table.php
@@ -9,11 +9,13 @@ use App\Models\Menu\MenuSub;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 new class extends BaseComponent
 {
     /** @var class-string<MenuSub> */
+    #[Locked]
     public string $modelInstance = MenuSub::class;
 
     public Menu $menu;

--- a/resources/views/components/cms/management/menu/⚡create-update/create-update.php
+++ b/resources/views/components/cms/management/menu/⚡create-update/create-update.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Symfony\Component\Finder\SplFileInfo;
@@ -21,6 +22,7 @@ use Symfony\Component\Finder\SplFileInfo;
 new class extends Component
 {
     /** @var class-string<Menu> */
+    #[Locked]
     public string $modelInstance = Menu::class;
 
     public bool $isUpdate = false;

--- a/resources/views/components/cms/management/menu/⚡table/table.php
+++ b/resources/views/components/cms/management/menu/⚡table/table.php
@@ -8,11 +8,13 @@ use App\Models\Menu\Menu;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 new class extends BaseComponent
 {
     /** @var class-string<Menu> */
+    #[Locked]
     public string $modelInstance = Menu::class;
 
     /**

--- a/resources/views/components/cms/management/permission/⚡create-update/create-update.php
+++ b/resources/views/components/cms/management/permission/⚡create-update/create-update.php
@@ -9,12 +9,14 @@ use App\DTOs\Cms\Management\Permission\UpdatePermissionData;
 use App\Models\Spatie\Permission;
 use Flux\Flux;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 new class extends Component
 {
     /** @var class-string<Permission> */
+    #[Locked]
     public string $modelInstance = Permission::class;
 
     public bool $isUpdate = false;

--- a/resources/views/components/cms/management/permission/⚡table/table.php
+++ b/resources/views/components/cms/management/permission/⚡table/table.php
@@ -7,11 +7,13 @@ use App\Livewire\BaseComponent;
 use App\Models\Spatie\Permission;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 new class extends BaseComponent
 {
     /** @var class-string<Permission> */
+    #[Locked]
     public string $modelInstance = Permission::class;
 
     /**

--- a/resources/views/components/cms/management/role/⚡create-update/create-update.php
+++ b/resources/views/components/cms/management/role/⚡create-update/create-update.php
@@ -9,12 +9,14 @@ use App\DTOs\Cms\Management\Role\UpdateRoleData;
 use App\Models\Spatie\Role;
 use Flux\Flux;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 new class extends Component
 {
     /** @var class-string<Role> */
+    #[Locked]
     public string $modelInstance = Role::class;
 
     public bool $isUpdate = false;

--- a/resources/views/components/cms/management/role/⚡permission/permission.php
+++ b/resources/views/components/cms/management/role/⚡permission/permission.php
@@ -7,10 +7,12 @@ use App\Livewire\BaseComponent;
 use App\Models\Spatie\Permission;
 use App\Models\Spatie\Role;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 
 new class extends BaseComponent
 {
     /** @var class-string<Permission> */
+    #[Locked]
     public string $modelInstance = Permission::class;
 
     /**

--- a/resources/views/components/cms/management/role/⚡table/table.php
+++ b/resources/views/components/cms/management/role/⚡table/table.php
@@ -7,11 +7,13 @@ use App\Livewire\BaseComponent;
 use App\Models\Spatie\Role;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 new class extends BaseComponent
 {
     /** @var class-string<Role> */
+    #[Locked]
     public string $modelInstance = Role::class;
 
     /**

--- a/resources/views/components/cms/management/user/⚡create-update/create-update.php
+++ b/resources/views/components/cms/management/user/⚡create-update/create-update.php
@@ -12,12 +12,14 @@ use Flux\Flux;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 new class extends Component
 {
     /** @var class-string<User> */
+    #[Locked]
     public string $modelInstance = User::class;
 
     public bool $isUpdate = false;

--- a/resources/views/components/cms/management/user/⚡table/table.php
+++ b/resources/views/components/cms/management/user/⚡table/table.php
@@ -8,11 +8,13 @@ use App\Livewire\BaseComponent;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 
 new class extends BaseComponent
 {
     /** @var class-string<User> */
+    #[Locked]
     public string $modelInstance = User::class;
 
     /**

--- a/resources/views/components/cms/management/user/⚡update-password/update-password.php
+++ b/resources/views/components/cms/management/user/⚡update-password/update-password.php
@@ -6,12 +6,14 @@ use App\Actions\Cms\Management\User\UpdateUserPasswordAction;
 use App\Models\User;
 use Flux\Flux;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
 new class extends Component
 {
     /** @var class-string<User> */
+    #[Locked]
     public string $modelInstance = User::class;
 
     public bool $isUpdate = false;


### PR DESCRIPTION
## What

Adds **Larastan** (PHPStan level 5) as the project's static type-checker, plus a small `#[Locked]` hardening pass on CMS management components.

### Larastan setup
- `larastan/larastan ^3.0` (PHPStan 2.2) in `require-dev`.
- `phpstan.neon.dist` — level 5, scans `app`, `database`, `routes`, `config`, and `resources/views/components` (Livewire MFC `⚡` folders); excludes `*.blade.php`.
- `phpstan-baseline.neon` — captures 138 pre-existing findings (mostly MFC anonymous-class + Pest test false-positives) so CI is green now; this file should shrink over time, never grow.
- `composer analyse` script (`--memory-limit=1G`).
- New `static-analysis` CI job in `.github/workflows/lint.yml`.
- `docs/architecture.md` updated: Larastan is now part of the golden rules, testing contract, and the new-feature checklist (`pint → analyse → test`).

### Hardening
- `#[Locked]` added to `$modelInstance` across CMS management components so it can't be tampered with client-side.

## Verification
- `composer analyse` → **No errors** (exit 0).
- Sanity-checked that Larastan catches a deliberate type error.
- `vendor/bin/pint --dirty` → passed.
- `php artisan test --compact` → **85 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)